### PR TITLE
feature: 안드로이드 백핸들러 동작시 webview 히스토리 백 하도록 수정

### DIFF
--- a/app/[...unmatched].tsx
+++ b/app/[...unmatched].tsx
@@ -5,6 +5,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams } from 'expo-router';
 import { config } from '@/src/utils/envConfig';
 import { useWebViewBridge } from '@/src/hooks/useWebViewBridge';
+import useWebViewBackHandler from '@/src/hooks/useWebViewBackHandler';
 
 /**
  * Catch-all 라우트
@@ -14,6 +15,8 @@ import { useWebViewBridge } from '@/src/hooks/useWebViewBridge';
 export default function UnmatchedRoute() {
   const webViewRef = useRef<WebView>(null);
   const { handleMessage } = useWebViewBridge(webViewRef);
+  const { navStateHandler } = useWebViewBackHandler(webViewRef);
+
   const { unmatched } = useLocalSearchParams<{ unmatched: string[] }>();
 
   const domain = config.domain;
@@ -33,6 +36,7 @@ export default function UnmatchedRoute() {
         ref={webViewRef}
         source={{ uri: webUrl }}
         onMessage={handleMessage}
+        onNavigationStateChange={navStateHandler}
         style={styles.webview}
       />
     </SafeAreaView>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'expo-router';
 import * as Linking from 'expo-linking';
 import { config } from '@/src/utils/envConfig';
 import { useWebViewBridge } from '@/src/hooks/useWebViewBridge';
+import useWebViewBackHandler from '@/src/hooks/useWebViewBackHandler';
 
 /**
  * 딥링크 URL에서 웹 경로 추출
@@ -33,6 +34,7 @@ export default function Index() {
   const router = useRouter();
   const webViewRef = useRef<WebView>(null);
   const { handleMessage } = useWebViewBridge(webViewRef);
+  const { navStateHandler } = useWebViewBackHandler(webViewRef);
 
   const domain = config.domain;
   // const DEFAULT_PATH = '/archives/detail/1';
@@ -82,6 +84,7 @@ export default function Index() {
           uri: webUrl,
         }}
         onMessage={handleMessage}
+        onNavigationStateChange={navStateHandler}
         style={{
           flex: 1,
         }}

--- a/src/hooks/useWebViewBackHandler.ts
+++ b/src/hooks/useWebViewBackHandler.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+import { BackHandler } from 'react-native';
+import { WebView, WebViewNavigation } from 'react-native-webview';
+import type { WebViewProps } from 'react-native-webview';
+
+const useWebViewBackHandler = (
+  webViewRef: React.RefObject<WebView<WebViewProps> | null>,
+) => {
+  const canGoBack = useRef(false);
+
+  const navStateHandler = (event: WebViewNavigation) => {
+    canGoBack.current = event.canGoBack;
+  };
+
+  useEffect(() => {
+    const backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => {
+        console.log('backHandler', canGoBack.current);
+        if (canGoBack.current) {
+          webViewRef.current?.goBack();
+          return true;
+        }
+      },
+    );
+
+    return () => {
+      backHandler.remove();
+    };
+  }, [canGoBack]);
+
+  return {
+    navStateHandler,
+  };
+};
+
+export default useWebViewBackHandler;


### PR DESCRIPTION
안드로이드 백핸들러 동작시 webview 우선 히스토리를 처리하도록 hook을 추가하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * WebView 기반 네비게이션에서 뒤로가기 버튼 동작이 개선되었습니다. 기기의 백 버튼을 누르면 WebView 내에서 이전 페이지로 이동할 수 있으며, 추가 페이지가 없을 때는 앱 기본 동작으로 돌아갑니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->