### PR TITLE
웹뷰 쿠키쉐어링 및 로그인유지 추가

### DIFF
--- a/adb-export.sh
+++ b/adb-export.sh
@@ -1,0 +1,2 @@
+adb reverse tcp:8080 tcp:8080
+adb reverse tcp:3000 tcp:3000

--- a/app/[...unmatched].tsx
+++ b/app/[...unmatched].tsx
@@ -6,6 +6,7 @@ import { useLocalSearchParams } from 'expo-router';
 import { config } from '@/src/utils/envConfig';
 import { useWebViewBridge } from '@/src/hooks/useWebViewBridge';
 import useWebViewBackHandler from '@/src/hooks/useWebViewBackHandler';
+import DoLinkWebView from '@/src/components/DoLinkWebView';
 
 /**
  * Catch-all 라우트
@@ -13,10 +14,6 @@ import useWebViewBackHandler from '@/src/hooks/useWebViewBackHandler';
  * 예: dolink://task/detail/101 → /task/detail/101
  */
 export default function UnmatchedRoute() {
-  const webViewRef = useRef<WebView>(null);
-  const { handleMessage } = useWebViewBridge(webViewRef);
-  const { navStateHandler } = useWebViewBackHandler(webViewRef);
-
   const { unmatched } = useLocalSearchParams<{ unmatched: string[] }>();
 
   const domain = config.domain;
@@ -32,13 +29,7 @@ export default function UnmatchedRoute() {
       edges={Platform.OS === 'ios' ? ['top'] : ['top', 'bottom']}
     >
       <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
-      <WebView
-        ref={webViewRef}
-        source={{ uri: webUrl }}
-        onMessage={handleMessage}
-        onNavigationStateChange={navStateHandler}
-        style={styles.webview}
-      />
+      <DoLinkWebView source={{ uri: webUrl }} />
     </SafeAreaView>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,8 @@
 import '../src/styles/global.css';
 import '../src/lib/nativewind-setup';
-import { useState, useEffect } from 'react';
-import { View, BackHandler, Platform, StatusBar } from 'react-native';
 import { Stack } from 'expo-router';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
-import type { ShareIntent } from 'expo-share-intent';
-import CollectionBottomSheet from '@/src/components/CollectionBottomSheet';
 
 export default function RootLayout() {
   return (

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -14,6 +14,8 @@ import * as Linking from 'expo-linking';
 import { config } from '@/src/utils/envConfig';
 import { useWebViewBridge } from '@/src/hooks/useWebViewBridge';
 import useWebViewBackHandler from '@/src/hooks/useWebViewBackHandler';
+import DebugButton from '@/src/components/DebugButton';
+import DoLinkWebView from '@/src/components/DoLinkWebView';
 
 /**
  * 딥링크 URL에서 웹 경로 추출
@@ -78,38 +80,8 @@ export default function Index() {
       edges={Platform.OS === 'ios' ? ['top'] : ['top', 'bottom']}
     >
       <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
-      <WebView
-        ref={webViewRef}
-        source={{
-          uri: webUrl,
-        }}
-        onMessage={handleMessage}
-        onNavigationStateChange={navStateHandler}
-        style={{
-          flex: 1,
-        }}
-        onError={(syntheticEvent) => {
-          const { nativeEvent } = syntheticEvent;
-          console.warn('❌ WebView Error:', nativeEvent);
-        }}
-        onHttpError={(syntheticEvent) => {
-          const { nativeEvent } = syntheticEvent;
-          console.warn('❌ WebView HTTP Error:', nativeEvent);
-        }}
-        onLoadStart={() => console.log('⏳ WebView Start Loading')}
-        onLoad={() => console.log('✅ WebView Load Success')}
-      />
-
-      {/* ✅ 개발 모드(__DEV__)일 때만 테스트 버튼 렌더링 */}
-      {__DEV__ && (
-        <TouchableOpacity
-          style={styles.testButton}
-          onPress={() => router.push('/test')}
-          activeOpacity={0.8}
-        >
-          <Text style={styles.testButtonText}>🧪</Text>
-        </TouchableOpacity>
-      )}
+      <DoLinkWebView source={{ uri: webUrl }} />
+      <DebugButton />
     </SafeAreaView>
   );
 }

--- a/src/components/DebugButton.tsx
+++ b/src/components/DebugButton.tsx
@@ -1,0 +1,43 @@
+import { TouchableOpacity } from 'react-native';
+import { useRouter } from 'expo-router';
+import { StyleSheet, Text } from 'react-native';
+
+export default function DebugButton() {
+  const router = useRouter();
+
+  if (!__DEV__) {
+    return null;
+  }
+
+  return (
+    <TouchableOpacity
+      style={styles.testButton}
+      onPress={() => router.push('/test')}
+      activeOpacity={0.8}
+    >
+      <Text style={styles.testButtonText}>🧪</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  testButton: {
+    position: 'absolute',
+    bottom: 20,
+    right: 20,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: '#FF6B6B',
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 3,
+    elevation: 5,
+  },
+  testButtonText: {
+    fontSize: 28,
+  },
+});

--- a/src/components/DoLinkShareIntentView.tsx
+++ b/src/components/DoLinkShareIntentView.tsx
@@ -1,0 +1,189 @@
+import React, { useRef, useState } from 'react';
+import {
+  View,
+  BackHandler,
+  StatusBar,
+  Linking,
+  Text,
+  TouchableOpacity,
+} from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import WebView from 'react-native-webview';
+import * as Clipboard from 'expo-clipboard';
+import { BaseBottomSheet } from './common/bottomSheet/baseBottomSheet';
+import type { ShareIntentData } from '../types/shareIntent';
+import type {
+  ShareIntentDataMessage,
+  AuthStatusMessage,
+} from '../bridge/types';
+import { config } from '../utils/envConfig';
+import DoLinkWebView from './DoLinkWebView';
+
+interface DoLinkShareIntentViewProps {
+  shareIntent?: ShareIntentData | null;
+}
+
+export default function DoLinkShareIntentView({
+  shareIntent,
+}: DoLinkShareIntentViewProps) {
+  const domain = config.domain;
+  const [visible, setVisible] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const webViewRef = useRef<WebView>(null);
+
+  const DEFAULT_PATH = '/share-intent';
+  const webViewUrl = `${domain}${DEFAULT_PATH}`;
+
+  // console.log('isError', isError);
+  console.log('webViewUrl', webViewUrl);
+
+  const handleClose = () => {
+    setVisible(false);
+    BackHandler.exitApp();
+  };
+
+  const handleWebViewLoad = () => {
+    if (!shareIntent || !webViewRef.current) return;
+
+    const message: ShareIntentDataMessage = {
+      type: 'shareIntent:data',
+      payload: {
+        text: shareIntent.text,
+        title: shareIntent.title,
+        url: shareIntent.url,
+        thumbnailUrl: shareIntent.thumbnailUrl,
+        contentType: shareIntent.type,
+      },
+    };
+
+    webViewRef.current.postMessage(JSON.stringify(message));
+  };
+
+  const handleError = async () => {
+    console.log('handleError');
+    // 데이터 유실 방지를 위해 미리 클립보드 복사
+    const sharedUrl = shareIntent?.url || shareIntent?.text || '';
+    if (sharedUrl) {
+      await Clipboard.setStringAsync(sharedUrl);
+    }
+    setIsError(true);
+  };
+
+  const handleAuthFailure = async () => {
+    // 1. 공유하려는 URL을 클립보드에 저장
+    const sharedUrl = shareIntent?.url || shareIntent?.text || '';
+    if (sharedUrl) {
+      await Clipboard.setStringAsync(sharedUrl);
+    }
+
+    // 2. 딥링크로 메인 앱 연다
+    Linking.openURL('dolink://');
+
+    // 3. 종료
+    handleClose();
+  };
+
+  const handleMessage = async (event: { nativeEvent: { data: string } }) => {
+    try {
+      const data = JSON.parse(event.nativeEvent.data);
+
+      if (data.type === 'auth:status') {
+        const { isAuthenticated } = (data as AuthStatusMessage).payload;
+
+        if (isAuthenticated) {
+          // 로그인 되어있다면 공유 데이터 내려줌
+          handleWebViewLoad();
+        } else {
+          // 로그인 되어있지 않다면 리다이렉트
+          await handleAuthFailure();
+        }
+      }
+    } catch (error) {
+      console.error('[DoLinkWebView] 메시지 처리 에러:', error);
+    }
+  };
+
+  // if (!visible) return null;
+
+  return (
+    <SafeAreaProvider>
+      <View className="flex-1 bg-transparent">
+        <StatusBar
+          translucent
+          backgroundColor="transparent"
+          barStyle="light-content"
+        />
+
+        {/* 오버레이 */}
+        <View
+          className="absolute inset-0 bg-black/50"
+          onTouchEnd={handleClose}
+        />
+
+        {/* BottomSheet */}
+        <View className="absolute bottom-0 left-0 right-0 bg-transparent">
+          <BaseBottomSheet onClose={handleClose} expandable>
+            <View className="flex-1 overflow-hidden rounded-xl bg-white px-5">
+              {isError ? (
+                /* 에러 UI (오프라인) */
+                <View className="flex-1">
+                  {/* 헤더 */}
+                  <View className="flex-row items-center justify-between py-2">
+                    <View className="flex-row items-center gap-2">
+                      <View className="h-6 w-1 rounded-full bg-point" />
+                      <Text className="text-display-2xl text-grey-900">
+                        할 일 담기
+                      </Text>
+                    </View>
+                    <TouchableOpacity className="flex-row items-center">
+                      <Text className="text-body-lg text-grey-600">
+                        + 모음 추가
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+
+                  {/* 중앙 안내 */}
+                  <View className="flex-1 items-center justify-center py-10">
+                    <View className="mb-6 h-24 w-24 items-center justify-center rounded-full bg-grey-50">
+                      {/* 아이콘 대체: 말풍선 모양 */}
+                      <View className="h-10 w-12 items-center justify-center rounded-2xl bg-grey-200">
+                        <View className="flex-row gap-1">
+                          <View className="h-1.5 w-1.5 rounded-full bg-grey-400" />
+                          <View className="h-1.5 w-1.5 rounded-full bg-grey-400" />
+                          <View className="h-1.5 w-1.5 rounded-full bg-grey-400" />
+                        </View>
+                        {/* 꼬리 부분 */}
+                        <View className="absolute -bottom-1 right-2 h-3 w-3 rotate-45 bg-grey-200" />
+                      </View>
+                    </View>
+                    <Text className="mb-2 text-heading-lg text-grey-700">
+                      네트워크가 불안정합니다
+                    </Text>
+                    <Text className="text-body-lg text-grey-400">
+                      연결을 확인 후 다시 시도해주세요
+                    </Text>
+                  </View>
+
+                  {/* 푸터 버튼 */}
+                  <TouchableOpacity
+                    disabled
+                    className="mb-4 h-14 w-full items-center justify-center rounded-2xl bg-grey-50"
+                  >
+                    <Text className="text-heading-md text-grey-300">담기</Text>
+                  </TouchableOpacity>
+                </View>
+              ) : (
+                /* 정상 웹뷰 */
+                <DoLinkWebView
+                  source={{ uri: webViewUrl }}
+                  onMessage={handleMessage}
+                  onError={handleError}
+                />
+              )}
+            </View>
+          </BaseBottomSheet>
+        </View>
+      </View>
+    </SafeAreaProvider>
+  );
+}

--- a/src/components/DoLinkShareIntentView.tsx
+++ b/src/components/DoLinkShareIntentView.tsx
@@ -31,7 +31,7 @@ export default function DoLinkShareIntentView({
   const [isError, setIsError] = useState(false);
   const webViewRef = useRef<WebView>(null);
 
-  const DEFAULT_PATH = '/share-intent';
+  const DEFAULT_PATH = '/';
   const webViewUrl = `${domain}${DEFAULT_PATH}`;
 
   // console.log('isError', isError);

--- a/src/components/DoLinkWebView.tsx
+++ b/src/components/DoLinkWebView.tsx
@@ -1,183 +1,37 @@
-import React, { useRef, useState } from 'react';
-import {
-  View,
-  BackHandler,
-  StatusBar,
-  Linking,
-  Text,
-  TouchableOpacity,
-} from 'react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
-import WebView from 'react-native-webview';
-import * as Clipboard from 'expo-clipboard';
-import { BaseBottomSheet } from './common/bottomSheet/baseBottomSheet';
-import type { ShareIntentData } from '../types/shareIntent';
-import type {
-  ShareIntentDataMessage,
-  AuthStatusMessage,
-} from '../bridge/types';
-import { config } from '../utils/envConfig';
+import { Platform, StatusBar } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StyleSheet } from 'react-native';
+import WebView, { WebViewProps } from 'react-native-webview';
+import useWebViewBackHandler from '../hooks/useWebViewBackHandler';
+import { useWebViewBridge } from '../hooks/useWebViewBridge';
+import { useRef } from 'react';
 
-interface DoLinkWebViewProps {
-  shareIntent?: ShareIntentData | null;
-}
+interface DoLinkWebViewProps extends WebViewProps {}
 
-export default function DoLinkWebView({ shareIntent }: DoLinkWebViewProps) {
-  const domain = config.domain;
-  const [visible, setVisible] = useState(true);
-  const [isError, setIsError] = useState(false);
+export default function DoLinkWebView({ style, ...props }: DoLinkWebViewProps) {
   const webViewRef = useRef<WebView>(null);
-
-  const DEFAULT_PATH = '/share-intent';
-  const webViewUrl = `${domain}${DEFAULT_PATH}`;
-
-  const handleClose = () => {
-    setVisible(false);
-    BackHandler.exitApp();
-  };
-
-  const handleWebViewLoad = () => {
-    if (!shareIntent || !webViewRef.current) return;
-
-    const message: ShareIntentDataMessage = {
-      type: 'shareIntent:data',
-      payload: {
-        text: shareIntent.text,
-        title: shareIntent.title,
-        url: shareIntent.url,
-        thumbnailUrl: shareIntent.thumbnailUrl,
-        contentType: shareIntent.type,
-      },
-    };
-
-    webViewRef.current.postMessage(JSON.stringify(message));
-  };
-
-  const handleError = async () => {
-    // 데이터 유실 방지를 위해 미리 클립보드 복사
-    const sharedUrl = shareIntent?.url || shareIntent?.text || '';
-    if (sharedUrl) {
-      await Clipboard.setStringAsync(sharedUrl);
-    }
-    setIsError(true);
-  };
-
-  const handleAuthFailure = async () => {
-    // 1. 공유하려는 URL을 클립보드에 저장
-    const sharedUrl = shareIntent?.url || shareIntent?.text || '';
-    if (sharedUrl) {
-      await Clipboard.setStringAsync(sharedUrl);
-    }
-
-    // 2. 딥링크로 메인 앱 연다
-    Linking.openURL('dolink://');
-
-    // 3. 종료
-    handleClose();
-  };
-
-  const handleMessage = async (event: { nativeEvent: { data: string } }) => {
-    try {
-      const data = JSON.parse(event.nativeEvent.data);
-
-      if (data.type === 'auth:status') {
-        const { isAuthenticated } = (data as AuthStatusMessage).payload;
-
-        if (isAuthenticated) {
-          // 로그인 되어있다면 공유 데이터 내려줌
-          handleWebViewLoad();
-        } else {
-          // 로그인 되어있지 않다면 리다이렉트
-          await handleAuthFailure();
-        }
-      }
-    } catch (error) {
-      console.error('[DoLinkWebView] 메시지 처리 에러:', error);
-    }
-  };
-
-  if (!visible) return null;
+  const { handleMessage } = useWebViewBridge(webViewRef);
+  const { navStateHandler } = useWebViewBackHandler(webViewRef);
 
   return (
-    <SafeAreaProvider>
-      <View className="flex-1 bg-transparent">
-        <StatusBar
-          translucent
-          backgroundColor="transparent"
-          barStyle="light-content"
-        />
-
-        {/* 오버레이 */}
-        <View
-          className="absolute inset-0 bg-black/50"
-          onTouchEnd={handleClose}
-        />
-
-        {/* BottomSheet */}
-        <View className="absolute bottom-0 left-0 right-0 bg-transparent">
-          <BaseBottomSheet onClose={handleClose} expandable>
-            <View className="flex-1 overflow-hidden rounded-xl bg-white px-5">
-              {isError ? (
-                /* 에러 UI (오프라인) */
-                <View className="flex-1">
-                  {/* 헤더 */}
-                  <View className="flex-row items-center justify-between py-2">
-                    <View className="flex-row items-center gap-2">
-                      <View className="h-6 w-1 rounded-full bg-point" />
-                      <Text className="text-display-2xl text-grey-900">
-                        할 일 담기
-                      </Text>
-                    </View>
-                    <TouchableOpacity className="flex-row items-center">
-                      <Text className="text-body-lg text-grey-600">
-                        + 모음 추가
-                      </Text>
-                    </TouchableOpacity>
-                  </View>
-
-                  {/* 중앙 안내 */}
-                  <View className="flex-1 items-center justify-center py-10">
-                    <View className="mb-6 h-24 w-24 items-center justify-center rounded-full bg-grey-50">
-                      {/* 아이콘 대체: 말풍선 모양 */}
-                      <View className="h-10 w-12 items-center justify-center rounded-2xl bg-grey-200">
-                        <View className="flex-row gap-1">
-                          <View className="h-1.5 w-1.5 rounded-full bg-grey-400" />
-                          <View className="h-1.5 w-1.5 rounded-full bg-grey-400" />
-                          <View className="h-1.5 w-1.5 rounded-full bg-grey-400" />
-                        </View>
-                        {/* 꼬리 부분 */}
-                        <View className="absolute -bottom-1 right-2 h-3 w-3 rotate-45 bg-grey-200" />
-                      </View>
-                    </View>
-                    <Text className="mb-2 text-heading-lg text-grey-700">
-                      네트워크가 불안정합니다
-                    </Text>
-                    <Text className="text-body-lg text-grey-400">
-                      연결을 확인 후 다시 시도해주세요
-                    </Text>
-                  </View>
-
-                  {/* 푸터 버튼 */}
-                  <TouchableOpacity
-                    disabled
-                    className="mb-4 h-14 w-full items-center justify-center rounded-2xl bg-grey-50"
-                  >
-                    <Text className="text-heading-md text-grey-300">담기</Text>
-                  </TouchableOpacity>
-                </View>
-              ) : (
-                /* 정상 웹뷰 */
-                <WebView
-                  ref={webViewRef}
-                  source={{ uri: webViewUrl }}
-                  onMessage={handleMessage}
-                  onError={handleError}
-                />
-              )}
-            </View>
-          </BaseBottomSheet>
-        </View>
-      </View>
-    </SafeAreaProvider>
+    <WebView
+      ref={webViewRef}
+      onMessage={handleMessage}
+      onNavigationStateChange={navStateHandler}
+      style={[styles.webview, style]}
+      sharedCookiesEnabled
+      javaScriptEnabled
+      {...props}
+    />
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  webview: {
+    flex: 1,
+  },
+});

--- a/src/components/DoLinkWebView.tsx
+++ b/src/components/DoLinkWebView.tsx
@@ -21,6 +21,15 @@ export default function DoLinkWebView({ style, ...props }: DoLinkWebViewProps) {
       style={[styles.webview, style]}
       sharedCookiesEnabled
       javaScriptEnabled
+      domStorageEnabled
+      originWhitelist={[
+        'http://localhost:8081',
+        'http://127.0.0.1:8081',
+        'http://10.0.2.2:8081',
+        'https://*',
+        'http://*',
+        'intent://*',
+      ]}
       {...props}
     />
   );

--- a/src/components/extension/ShareIntentRouter.tsx
+++ b/src/components/extension/ShareIntentRouter.tsx
@@ -1,13 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { BackHandler, Linking } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import DoLinkWebView from '../DoLinkWebView';
 import type { ShareIntentData } from '../../types/shareIntent';
+import DoLinkShareIntentView from '../DoLinkShareIntentView';
 
 /**
  * Share Intent 진입 시 웹뷰를 띄워 로그인 여부를 브릿지로 확인하는 라우터
  */
 export default function ShareIntentRouter(props: ShareIntentData) {
+  console.log('ShareIntentRouter', props);
   const [shareIntent, setShareIntent] = useState<ShareIntentData | null>(null);
 
   // 로그인 여부는 DoLinkWebView 내부의 브릿지 통신을 통해 확인합니다.
@@ -26,5 +25,5 @@ export default function ShareIntentRouter(props: ShareIntentData) {
 
   // DoLinkWebView를 항상 렌더링하며, 내부에서 로그인 여부에 따라 분기 처리함
 
-  return <DoLinkWebView shareIntent={shareIntent} />;
+  return <DoLinkShareIntentView shareIntent={shareIntent} />;
 }


### PR DESCRIPTION


### 작업
- 앱에서 로그인시 쿠키와 access token 유지되도록 작업
- DoLinkWebView를 두링크용 웹뷰 공통설정으로 작업해두고, 기존코드는 DoLinkShareWebView로 변경함

<img width="435" height="667" alt="image" src="https://github.com/user-attachments/assets/669bdb5e-87e3-453a-9807-2a929dc92c0b" />



### 별도 이슈
- 웹에서 로그인후 앱에서 로그인시 서버의 redis에서 리프레시토큰을 유지하는동안 로그인이 안되는 문제가있음 백엔드팀 전달예정
- 이후 바텀시트의 처리는 웹뷰로할지, 앱으로 할지에 대한 결정은 필요함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공유 기능 강화 및 모바일 앱 통합 개선
  * 개발자 디버그 도구 추가

* **개선 사항**
  * 웹 콘텐츠 렌더링 로직 최적화 및 간소화
  * 공유 인텐트 처리 워크플로우 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->