### PR TITLE
Feat: WebView 키보드 회피 및 URL 상태 추적 개선

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,15 +1,19 @@
 import { useRef, useState, useEffect } from 'react';
-import { StatusBar, Platform, StyleSheet } from 'react-native';
-import WebView from 'react-native-webview';
+import {
+  StatusBar,
+  Platform,
+  StyleSheet,
+  Keyboard,
+  KeyboardAvoidingView,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams } from 'expo-router';
 import * as Linking from 'expo-linking';
 import { config } from '@/src/utils/envConfig';
-import { useWebViewBridge } from '@/src/hooks/useWebViewBridge';
-import useWebViewBackHandler from '@/src/hooks/useWebViewBackHandler';
 import DebugButton from '@/src/components/DebugButton';
 import DoLinkWebView from '@/src/components/DoLinkWebView';
 import { useGetUser } from '@/src/api/generated/endpoints/user/user';
+// use React Native's built-in KeyboardAvoidingView
 
 /**
  * 딥링크 URL에서 웹 경로 추출
@@ -63,6 +67,31 @@ export default function Index() {
 
   const webUrl = `${domain}${webPath}`;
 
+  const [currentUrl, setCurrentUrl] = useState(webUrl);
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const isTaskForm = /\/task\/(edit|create)/.test(currentUrl);
+  const needsKeyboardAvoiding = isTaskForm && keyboardVisible;
+
+  useEffect(() => {
+    const showSub = Keyboard.addListener('keyboardDidShow', () =>
+      setKeyboardVisible(true),
+    );
+    const hideSub = Keyboard.addListener('keyboardDidHide', () =>
+      setKeyboardVisible(false),
+    );
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  // When navigating away from task edit/create, ensure keyboard is dismissed
+  useEffect(() => {
+    if (!isTaskForm) {
+      Keyboard.dismiss();
+    }
+  }, [currentUrl, isTaskForm]);
+
   useEffect(() => {
     console.log('🌐 WebView Loading URL:', webUrl);
     console.log('📱 Platform:', Platform.OS);
@@ -75,7 +104,16 @@ export default function Index() {
       edges={Platform.OS === 'ios' ? ['top'] : ['top', 'bottom']}
     >
       <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
-      <DoLinkWebView source={{ uri: webUrl }} />
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior="padding"
+        enabled={needsKeyboardAvoiding}
+      >
+        <DoLinkWebView
+          source={{ uri: webUrl }}
+          onNavigationStateChange={(e) => setCurrentUrl(e.url)}
+        />
+      </KeyboardAvoidingView>
       <DebugButton />
     </SafeAreaView>
   );

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -11,6 +11,7 @@ import type {
   LinkPayload,
   SharePayload,
   OsSharePayload,
+  AuthMessageType,
 } from './types';
 import { sendToWebView, createBridgeErrorResponse } from './sender';
 import { draftHandler } from './handlers/draftHandler';

--- a/src/components/DoLinkWebView.tsx
+++ b/src/components/DoLinkWebView.tsx
@@ -7,13 +7,18 @@ import { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes';
 
 interface DoLinkWebViewProps extends WebViewProps {}
 
-export default function DoLinkWebView({ style, ...props }: DoLinkWebViewProps) {
+export default function DoLinkWebView({
+  style,
+  onNavigationStateChange: onNavChange,
+  ...props
+}: DoLinkWebViewProps) {
   const webViewRef = useRef<WebView>(null);
   const { handleMessage } = useWebViewBridge(webViewRef);
   const { navStateHandler } = useWebViewBackHandler(webViewRef);
 
   const handleNavigationStateChange = (event: WebViewNavigation) => {
     navStateHandler(event);
+    onNavChange?.(event);
   };
 
   return (


### PR DESCRIPTION
## 작업 진행

### 1. 할일 상세 및 작성 페이지 (Task Form) 키보드 회피 로직 적용
* **KeyboardAvoidingView 적용**: WebView 내 `/task/create` 및 `/task/edit` 경로 진입 시, 입력창 포커스 시 키보드가 UI를 가리지 않도록 처리했습니다.
* **자동 키보드 닫기**: 폼 입력 중 뒤로가기나 다른 탭 이동으로 페이지를 벗어날 경우, `Keyboard.dismiss()`를 통해 열려있던 키보드가 자동으로 닫히도록 개선했습니다.

### 2. WebView 현재 페이지 URL 상태 추적 기능 추가
* **상태 감지 개선**: `DoLinkWebView`의 `onNavigationStateChange` 이벤트를 상위(`app/index.tsx`)로 전달하여, 현재 렌더링 중인 웹 주소(`currentUrl`)를 RN 사이드에서 실시간으로 감지할 수 있게 했습니다.

### 3. Type Import 에러 수정
* **Bridge 타입 안정화**: `src/bridge/index.ts`에서 누락되었던 `AuthMessageType` 타입을 import하여 빌드 및 타입 에러를 해결했습니다.

---

## 주요 변경 사항

| 파일 경로 | 변경 내용 |
| :--- | :--- |
| `app/index.tsx` | `currentUrl` 및 `keyboardVisible` 상태 관리 로직 추가. 정규식을 활용해 `/task/(edit\|create)` 경로에서만 `<KeyboardAvoidingView behavior="padding">` 활성화. |
| `src/components/DoLinkWebView.tsx` | 외부에서 `onNavigationStateChange` props를 주입받아 이벤트 발생 시 호출하도록 수정. |
| `src/bridge/index.ts` | `AuthMessageType` 타입 import 구문 추가. |

---

## 스크린샷

https://github.com/user-attachments/assets/c13d7e6a-24f1-4606-a85a-33d634c4d8e2


---

## 참고 및 확인 사항 (리뷰어에게)

1. 실제 AOS에서 정상적으로 동작하는지 
-  실제 제 기기에서는 app과, 하단 버튼이 밀리는 현상이 있었습니다 이슈로 등록해 추후 해결하도록 하겠습니다

---
## 관련 이슈 
ref #16 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 웹뷰 네비게이션 추적으로 현재 URL 상태를 반영
  * 외부 네비게이션 콜백 지원으로 상태 변경에 대한 연동 개선

* **Improvements**
  * 키보드 표시 시 자동 레이아웃 조정으로 입력 필드 접근성 향상
  * 작업 편집/생성 모드 제외 시 키보드 자동 닫힘 동작 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->