### PR TITLE
feat(auth): Google 네이티브 로그인 및 토큰 동기화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ fastlane/credentials/
 .vscode
 
 google-services.json
+google-services-*
 debug.keystore
 
 # act (local GitHub Actions)

--- a/app.config.js
+++ b/app.config.js
@@ -6,8 +6,8 @@ export default {
     scheme: 'dolink',
     name: 'dolink',
     slug: 'dolink',
-    version: '1.0.3',
-    runtimeVersion: '1.0.1',
+    version: '1.1.0',
+    runtimeVersion: '1.1.0',
     orientation: 'portrait',
     icon: './assets/icon.png',
     userInterfaceStyle: 'light',
@@ -24,6 +24,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: 'com.teamdolink.dolink',
+      buildNumber: '20',
       infoPlist: {
         LSApplicationQueriesSchemes: ['http', 'https', 'tel', 'mailto'],
       },
@@ -37,7 +38,7 @@ export default {
       edgeToEdgeEnabled: true,
       predictiveBackGestureEnabled: false,
       package: 'com.teamdolink.dolink',
-      versionCode: 14,
+      versionCode: 20,
       intentFilters: [
         {
           action: 'VIEW',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dolink-app-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dolink-app-client",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@dexical/expo-store-signing": "^1.0.14",
         "@react-native-async-storage/async-storage": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-firebase/app": "^23.8.6",
         "@react-native-firebase/crashlytics": "^23.8.6",
+        "@react-native-google-signin/google-signin": "^16.1.2",
         "@tanstack/react-query": "^5.90.20",
         "axios": "^1.13.4",
         "expo": "~54.0.33",
@@ -4838,6 +4839,25 @@
       "peerDependencies": {
         "@react-native-firebase/app": "23.8.6",
         "expo": ">=47.0.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native-google-signin/google-signin": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@react-native-google-signin/google-signin/-/google-signin-16.1.2.tgz",
+      "integrity": "sha512-1hf4pRmpnS5t0dHtqU72Q1FmWzsCZR2Sm3uVQbbfMKeNPl5TKjpAsP6F8QTZ9L+Q6Cnn9tL9BXpDCb1nyutdCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://universal-sign-in.com"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.40",
+        "react": "*",
+        "react-native": "*"
       },
       "peerDependenciesMeta": {
         "expo": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dolink-app-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "./index.tsx",
   "scripts": {
     "start": "expo start",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-firebase/app": "^23.8.6",
     "@react-native-firebase/crashlytics": "^23.8.6",
+    "@react-native-google-signin/google-signin": "^16.1.2",
     "@tanstack/react-query": "^5.90.20",
     "axios": "^1.13.4",
     "expo": "~54.0.33",

--- a/src/bridge/handlers/authHandler.ts
+++ b/src/bridge/handlers/authHandler.ts
@@ -9,14 +9,24 @@ import { issueAccessToken } from '@/src/api/generated/endpoints/auth/auth';
  * 로그인 성공 감지 또는 auth:reissue 처리에서 공통 사용.
  */
 export const performReissueFromCookies = async (): Promise<string | null> => {
-  const { setAccessToken, setRefreshToken } = useAuthStore.getState();
+  const {
+    setAccessToken,
+    setRefreshToken,
+    refreshToken: storedRefresh,
+  } = useAuthStore.getState();
   const cookies = await NitroCookies.get(config.domain);
 
-  if (!cookies) return null;
+  const cookieRefresh = cookies?.['refresh']?.value;
+  const refreshToken = cookieRefresh ?? storedRefresh ?? null;
 
-  const refreshToken = cookies['refresh']?.value;
-  if (refreshToken) {
-    setRefreshToken(refreshToken);
+  if (!refreshToken) {
+    return null;
+  }
+
+  if (cookieRefresh) {
+    setRefreshToken(cookieRefresh);
+  } else if (storedRefresh) {
+    setRefreshToken(storedRefresh);
   }
 
   try {

--- a/src/bridge/handlers/googleAuthHandler.ts
+++ b/src/bridge/handlers/googleAuthHandler.ts
@@ -1,0 +1,113 @@
+import { GoogleSignin } from '@react-native-google-signin/google-signin';
+import { Platform } from 'react-native';
+import NitroCookies from 'react-native-nitro-cookies';
+import useAuthStore from '@/src/stores/useAuthStore';
+import { config } from '@/src/utils/envConfig';
+
+GoogleSignin.configure({
+  webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,
+  offlineAccess: true,
+});
+
+function logGoogleAuthError(error: unknown): void {
+  console.error('[GoogleAuth] 로그인 오류 (원본)', error);
+  if (error !== null && typeof error === 'object') {
+    const dump: Record<string, unknown> = {};
+    for (const key of Object.getOwnPropertyNames(error)) {
+      dump[key] = (error as Record<string, unknown>)[key];
+    }
+    console.error('[GoogleAuth] 로그인 오류 (전체 필드)', dump);
+  }
+}
+
+/**
+ * Google 로그인 진행 후 서버에서 JWT 토큰 발급
+ * - Google Sign-In → idToken 획득
+ * - POST /v1/auth/oauth/google/native → accessToken + refreshToken 발급
+ * - Zustand + SecureStore 저장
+ * @returns accessToken (웹으로 전달할 토큰) | null (실패 시)
+ */
+export const performGoogleLogin = async (): Promise<string | null> => {
+  try {
+    await GoogleSignin.hasPlayServices();
+    const response = await GoogleSignin.signIn();
+
+    console.log('response', response);
+    const idToken = response.data?.idToken;
+
+    console.log('idToken', idToken);
+    if (!idToken) {
+      console.error('[GoogleAuth] idToken을 받지 못했습니다');
+      return null;
+    }
+
+    console.log('config.apiUrl', config.apiUrl);
+    const serverResponse = await fetch(
+      `${config.apiUrl}/v1/auth/oauth/google/native`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ idToken }),
+      },
+    );
+
+    console.log('serverResponse', serverResponse);
+    if (!serverResponse.ok) {
+      let bodySnippet = '';
+      try {
+        bodySnippet = (await serverResponse.text()).slice(0, 500);
+      } catch {
+        /* ignore */
+      }
+      console.error(
+        '[GoogleAuth] 서버 응답 오류:',
+        serverResponse.status,
+        bodySnippet ? `body: ${bodySnippet}` : '',
+      );
+      return null;
+    }
+
+    const json = await serverResponse.json();
+    const accessToken: string | undefined = json?.result?.accessToken;
+    const refreshToken: string | undefined = json?.result?.refreshToken;
+
+    if (!accessToken || !refreshToken) {
+      console.error(
+        '[GoogleAuth] 서버 응답에 accessToken 또는 refreshToken이 없습니다',
+        { hasAccess: !!accessToken, hasRefresh: !!refreshToken },
+      );
+      return null;
+    }
+
+    const { setAccessToken, setRefreshToken } = useAuthStore.getState();
+    setAccessToken(accessToken);
+    setRefreshToken(refreshToken);
+
+    const webOrigin = config.domain;
+    if (webOrigin?.startsWith('http')) {
+      try {
+        await NitroCookies.set(
+          webOrigin,
+          {
+            name: 'refresh',
+            value: refreshToken,
+            path: '/',
+            secure: webOrigin.startsWith('https'),
+            httpOnly: false,
+            expires: new Date(
+              Date.now() + 90 * 24 * 60 * 60 * 1000,
+            ).toISOString(),
+          },
+          Platform.OS === 'ios',
+        );
+      } catch (e) {
+        console.warn('[GoogleAuth] WebView용 refresh 쿠키 동기화 실패', e);
+      }
+    }
+
+    return accessToken;
+  } catch (error: unknown) {
+    logGoogleAuthError(error);
+    return null;
+  }
+};

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -29,6 +29,7 @@ import { clipboardHandler } from './handlers/clipboardHandler';
 import { linkHandler } from './handlers/linkHandler';
 import { shareHandler, osShareHandler } from './handlers/shareHandler';
 import { authHandler } from './handlers/authHandler';
+import { performGoogleLogin } from './handlers/googleAuthHandler';
 import useAuthStore from '../stores/useAuthStore';
 
 /**
@@ -194,6 +195,12 @@ export const handleBridgeMessage = async (
     if (type === 'auth:login') {
       await authHandler('auth:login', {});
       const accessToken = useAuthStore.getState().accessToken;
+      sendAuthLoginToWeb(webViewRef, accessToken);
+      return;
+    }
+
+    if (type === 'auth:google-login') {
+      const accessToken = await performGoogleLogin();
       sendAuthLoginToWeb(webViewRef, accessToken);
       return;
     }

--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -14,7 +14,10 @@ export type ClipboardMessageType =
   | 'clipboard:error'; // Native → WebView 에러 응답
 
 // Auth 메시지 타입
-export type AuthMessageType = 'auth:login' | 'auth:logout';
+export type AuthMessageType =
+  | 'auth:login'
+  | 'auth:logout'
+  | 'auth:google-login';
 
 // Auth Handler Payload/Response (웹→앱 auth 메시지 처리용)
 export type AuthPayload = Record<string, never>;


### PR DESCRIPTION
- @react-native-google-signin/google-signin 의존성 추가
- auth:google-login 브리지로 idToken 수집 후 서버 native 엔드포인트 호출
- access·refresh 저장 및 NitroCookies로 WebView refresh 동기화
- performReissueFromCookies에서 스토어 refresh 폴백
- google-services-* .gitignore 보강

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * Google Sign-In을 통한 네이티브 인증 기능 추가
  * 토큰 동기화 및 저장소 관리 개선

* **수정 사항**
  * 새로운 인증 메시지 타입 지원

* **작업**
  * 의존성 추가
  * 버전 관리 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->