### PR TITLE
ci: add iOS TestFlight deploy workflow

### DIFF
--- a/.github/workflows/ios-testflight-fastlane.yml
+++ b/.github/workflows/ios-testflight-fastlane.yml
@@ -1,0 +1,57 @@
+name: iOS TestFlight Deploy (Fastlane)
+
+on:
+  push:
+    tags:
+      - "ios-release-*"
+  workflow_dispatch:
+
+jobs:
+  deploy-ios:
+    runs-on: macos-latest
+    environment: production
+    env:
+      CI: true
+      RELEASE_TAG: ${{ github.ref_name }}
+      EXPO_PUBLIC_DOMAIN: ${{ vars.EXPO_PUBLIC_DOMAIN }}
+      EXPO_PUBLIC_API_URL: ${{ vars.EXPO_PUBLIC_API_URL }}
+      EXPO_PUBLIC_ANDROID_EMULATOR_DOMAIN: ${{ vars.EXPO_PUBLIC_ANDROID_EMULATOR_DOMAIN }}
+      EXPO_PUBLIC_DEBUG_INBOX: ${{ vars.EXPO_PUBLIC_DEBUG_INBOX }}
+      EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID }}
+      APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+      APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+      MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      IOS_SCHEME: ${{ secrets.IOS_SCHEME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Generate .env for Expo
+        run: node -e "const fs=require('fs'); const lines=[`EXPO_PUBLIC_DOMAIN=${process.env.EXPO_PUBLIC_DOMAIN||''}`,`EXPO_PUBLIC_API_URL=${process.env.EXPO_PUBLIC_API_URL||''}`,`EXPO_PUBLIC_ANDROID_EMULATOR_DOMAIN=${process.env.EXPO_PUBLIC_ANDROID_EMULATOR_DOMAIN||''}`,`EXPO_PUBLIC_DEBUG_INBOX=${process.env.EXPO_PUBLIC_DEBUG_INBOX||''}`,`EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=${process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID||''}`].join('\n')+'\n'; fs.writeFileSync('.env', lines); console.log('wrote .env');"
+
+      - name: Deploy to TestFlight
+        run: bundle exec fastlane ios deploy_testflight

--- a/docs/superpowers/plans/2026-05-17-ios-testflight-actions.md
+++ b/docs/superpowers/plans/2026-05-17-ios-testflight-actions.md
@@ -1,0 +1,153 @@
+# iOS TestFlight Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GitHub Actions workflow that deploys the iOS app to TestFlight through the existing Fastlane lane.
+
+**Architecture:** Add one isolated workflow file under `.github/workflows/`. The workflow owns CI setup and environment wiring only; the actual iOS prebuild, signing, archive, and TestFlight upload remain inside `fastlane ios deploy_testflight`.
+
+**Tech Stack:** GitHub Actions, Expo, npm, Ruby/Bundler, Fastlane, Apple App Store Connect API, Fastlane Match.
+
+---
+
+## File Structure
+
+- Create: `.github/workflows/ios-testflight-fastlane.yml`
+  - Responsibility: Trigger iOS TestFlight deployment on `ios-release-*` tags or manual dispatch, set up CI dependencies, generate Expo `.env`, and call Fastlane.
+- Verify only: `.github/workflows/android-playstore-fastlane.yml`
+  - Responsibility: Existing Android deployment workflow. It must remain unchanged.
+
+## Task 1: Add iOS TestFlight Workflow
+
+**Files:**
+- Create: `.github/workflows/ios-testflight-fastlane.yml`
+- Verify only: `.github/workflows/android-playstore-fastlane.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/ios-testflight-fastlane.yml` with this exact content:
+
+```yaml
+name: iOS TestFlight Deploy (Fastlane)
+
+on:
+  push:
+    tags:
+      - "ios-release-*"
+  workflow_dispatch:
+
+jobs:
+  deploy-ios:
+    runs-on: macos-latest
+    environment: production
+    env:
+      CI: true
+      RELEASE_TAG: ${{ github.ref_name }}
+      EXPO_PUBLIC_DOMAIN: ${{ vars.EXPO_PUBLIC_DOMAIN }}
+      EXPO_PUBLIC_API_URL: ${{ vars.EXPO_PUBLIC_API_URL }}
+      EXPO_PUBLIC_ANDROID_EMULATOR_DOMAIN: ${{ vars.EXPO_PUBLIC_ANDROID_EMULATOR_DOMAIN }}
+      EXPO_PUBLIC_DEBUG_INBOX: ${{ vars.EXPO_PUBLIC_DEBUG_INBOX }}
+      EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID }}
+      APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+      APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+      MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      IOS_SCHEME: ${{ secrets.IOS_SCHEME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Generate .env for Expo
+        run: node -e "const fs=require('fs'); const lines=[`EXPO_PUBLIC_DOMAIN=${process.env.EXPO_PUBLIC_DOMAIN||''}`,`EXPO_PUBLIC_API_URL=${process.env.EXPO_PUBLIC_API_URL||''}`,`EXPO_PUBLIC_ANDROID_EMULATOR_DOMAIN=${process.env.EXPO_PUBLIC_ANDROID_EMULATOR_DOMAIN||''}`,`EXPO_PUBLIC_DEBUG_INBOX=${process.env.EXPO_PUBLIC_DEBUG_INBOX||''}`,`EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=${process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID||''}`].join('\n')+'\n'; fs.writeFileSync('.env', lines); console.log('wrote .env');"
+
+      - name: Deploy to TestFlight
+        run: bundle exec fastlane ios deploy_testflight
+```
+
+- [ ] **Step 2: Validate the workflow exists and has the intended trigger**
+
+The workflow intentionally does not set optional Fastlane values such as `IOS_APP_IDENTIFIER`, `APPLE_TEAM_ID`, `APP_STORE_CONNECT_TEAM_ID`, `MATCH_TYPE`, or `MATCH_READONLY`. If an optional GitHub secret is absent, GitHub Actions can expose it as an empty string, which would override Fastlane defaults like `com.teamdolink.dolink`, `appstore`, and readonly signing.
+
+Run:
+
+```bash
+rg -n 'ios-release-\*|workflow_dispatch|bundle exec fastlane ios deploy_testflight' .github/workflows/ios-testflight-fastlane.yml
+```
+
+Expected output includes:
+
+```text
+6:      - "ios-release-*"
+7:  workflow_dispatch:
+57:        run: bundle exec fastlane ios deploy_testflight
+```
+
+The exact line number for the deploy step may differ if GitHub Actions expression formatting changes, but all three strings must be present.
+
+- [ ] **Step 3: Validate YAML syntax with Ruby**
+
+Run:
+
+```bash
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ios-testflight-fastlane.yml'); puts 'valid yaml'"
+```
+
+Expected output:
+
+```text
+valid yaml
+```
+
+- [ ] **Step 4: Confirm Android workflow was not modified**
+
+Run:
+
+```bash
+git diff -- .github/workflows/android-playstore-fastlane.yml
+```
+
+Expected output: no output.
+
+- [ ] **Step 5: Review the final diff**
+
+Run:
+
+```bash
+git diff --no-index -- /dev/null .github/workflows/ios-testflight-fastlane.yml || true
+```
+
+Expected: the diff only adds `.github/workflows/ios-testflight-fastlane.yml`.
+
+- [ ] **Step 6: Commit implementation**
+
+Run:
+
+```bash
+git add .github/workflows/ios-testflight-fastlane.yml docs/superpowers/plans/2026-05-17-ios-testflight-actions.md
+git commit -m "ci: add ios testflight deploy workflow"
+```
+
+Expected: a commit containing the iOS workflow and this implementation plan.

--- a/docs/superpowers/specs/2026-05-17-ios-testflight-actions-design.md
+++ b/docs/superpowers/specs/2026-05-17-ios-testflight-actions-design.md
@@ -1,0 +1,93 @@
+# iOS TestFlight GitHub Actions Design
+
+## Context
+
+The repository already has an Android Play Store workflow at `.github/workflows/android-playstore-fastlane.yml`. Android deploys on `release-*` tags and manual dispatch, sets up Node, Ruby, Java, Expo public environment values, restores Android-specific signing files, runs Expo prebuild, builds with Fastlane, and uploads to Google Play.
+
+iOS deployment support already exists in Fastlane:
+
+- `package.json` exposes `deploy:ios` as `bundle exec fastlane ios deploy_testflight`.
+- `fastlane/Fastfile` defines `ios deploy_testflight`.
+- The iOS lane regenerates the native iOS project with Expo prebuild, syncs signing through `match`, builds the app, and uploads it to TestFlight.
+
+The missing piece is a GitHub Actions workflow that calls this existing iOS lane.
+
+## Requirements
+
+- Add a separate GitHub Actions workflow for iOS TestFlight deployment.
+- Trigger iOS deployment with a separate tag pattern, not Android's `release-*` tag.
+- Use `ios-release-*` as the iOS release tag pattern.
+- Also support manual execution through `workflow_dispatch`.
+- Use the existing Fastlane lane: `bundle exec fastlane ios deploy_testflight`.
+- Use a macOS runner because iOS builds require Xcode.
+- Keep Expo public values aligned with the existing Android workflow.
+- Use GitHub Actions secrets for iOS-specific deployment credentials and configuration.
+- Do not change Android deployment behavior.
+- Do not modify generated API files or native iOS files as part of this workflow-only change.
+
+## Workflow Design
+
+Create `.github/workflows/ios-testflight-fastlane.yml`.
+
+The workflow will have one job:
+
+- Job name: `deploy-ios`
+- Runner: `macos-latest`
+- Environment: `production`
+- Trigger:
+  - `push.tags: ["ios-release-*"]`
+  - `workflow_dispatch`
+
+The job will:
+
+1. Check out the repository.
+2. Set up Node 20 with npm cache using `package-lock.json`.
+3. Set up Ruby 3.2 with Bundler cache.
+4. Install Java 17. This keeps Expo prebuild and React Native tooling consistent with Android CI, even though the final build is iOS.
+5. Install JavaScript dependencies with `npm ci`.
+6. Generate `.env` for Expo using the same public Expo values used by the Android workflow.
+7. Run `bundle exec fastlane ios deploy_testflight`.
+
+## Environment Variables
+
+Expo public values should follow the existing Android workflow pattern:
+
+- `EXPO_PUBLIC_DOMAIN`
+- `EXPO_PUBLIC_API_URL`
+- `EXPO_PUBLIC_ANDROID_EMULATOR_DOMAIN`
+- `EXPO_PUBLIC_DEBUG_INBOX`
+- `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID`
+
+iOS-specific deployment values will come from GitHub Actions secrets:
+
+- `APP_STORE_CONNECT_API_KEY_KEY_ID`
+- `APP_STORE_CONNECT_API_KEY_ISSUER_ID`
+- `APP_STORE_CONNECT_API_KEY_CONTENT`
+- `MATCH_GIT_URL`
+- `MATCH_PASSWORD`
+- `IOS_SCHEME`
+
+Optional iOS values can also be wired from secrets so Fastlane can use them when present:
+
+- `IOS_APP_IDENTIFIER`
+- `APPLE_TEAM_ID`
+- `APP_STORE_CONNECT_TEAM_ID`
+- `MATCH_TYPE`
+- `MATCH_READONLY`
+
+## Error Handling
+
+Fastlane already performs required environment validation through `ensure_env_vars` for the mandatory iOS deployment values. The workflow should rely on that validation instead of duplicating a separate shell validation block.
+
+The `.env` generation step should mirror the Android workflow so Expo receives predictable values during prebuild. Missing Expo values should become empty strings, matching the existing workflow behavior.
+
+## Testing
+
+Before considering the change complete:
+
+- Validate the workflow YAML parses.
+- Confirm the new workflow contains the intended `ios-release-*` tag trigger.
+- Confirm the deploy step calls `bundle exec fastlane ios deploy_testflight`.
+- Confirm no Android workflow behavior changed.
+
+The actual TestFlight upload requires real GitHub Actions secrets, Apple credentials, Match repository access, and App Store Connect access, so it cannot be fully verified locally.

--- a/docs/superpowers/specs/2026-05-17-ios-testflight-actions-design.md
+++ b/docs/superpowers/specs/2026-05-17-ios-testflight-actions-design.md
@@ -67,7 +67,7 @@ iOS-specific deployment values will come from GitHub Actions secrets:
 - `MATCH_PASSWORD`
 - `IOS_SCHEME`
 
-Optional iOS values can also be wired from secrets so Fastlane can use them when present:
+Optional iOS values should not be wired by default because absent GitHub secrets can become empty string environment variables, which would override Fastlane defaults. If the project later needs to override these values, add them deliberately and ensure they are non-empty:
 
 - `IOS_APP_IDENTIFIER`
 - `APPLE_TEAM_ID`


### PR DESCRIPTION
## Summary
- Add a separate GitHub Actions workflow for iOS TestFlight deployment.
- Trigger iOS deploys with `ios-release-*` tags and manual `workflow_dispatch`.
- Reuse the existing Fastlane lane: `bundle exec fastlane ios deploy_testflight`.

## Notes
- iOS-specific required deployment values are wired from GitHub Actions secrets.
- Optional Fastlane env values are intentionally not wired by default so empty secrets do not override Fastlane defaults.
- Android deployment workflow behavior is unchanged.

## Test Plan
- `npm run lint`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ios-testflight-fastlane.yml'); puts 'valid yaml'"`
- `rg -n 'ios-release-\\*|workflow_dispatch|bundle exec fastlane ios deploy_testflight' .github/workflows/ios-testflight-fastlane.yml`
- `git diff HEAD -- .github/workflows/android-playstore-fastlane.yml`
